### PR TITLE
Feat: Redux setup & ThemeProvider context.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,18 @@
 import { Container } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
 import React from 'react';
 
+import { useAppSelector } from './redux/hooks';
+import { darkTheme, lightTheme } from './styles/theme';
+
 function App() {
+  const theme = useAppSelector((state) => state.theme);
+
   return (
-    <div className="App">
-      <Container>
-        {/* 
+    <ThemeProvider theme={theme.darkTheme ? darkTheme : lightTheme}>
+      <div className="App">
+        <Container>
+          {/* 
           
           <Hero />
           <Trending />
@@ -14,8 +21,9 @@ function App() {
           </Features>
           
           */}
-      </Container>
-    </div>
+        </Container>
+      </div>
+    </ThemeProvider>
   );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,8 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
 import App from './App';
+import { store } from './redux/store';
 import reportWebVitals from './reportWebVitals';
-import { store } from './store';
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+
+import type { RootState, AppDispatch } from './store';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,7 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import theme from './theme/themeSlice';
+
 export const store = configureStore({
-  reducer: {},
+  reducer: {
+    theme,
+  },
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/redux/theme/themeSlice.ts
+++ b/src/redux/theme/themeSlice.ts
@@ -1,5 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import type { RootState } from '../store';
+
 interface ThemeState {
   darkTheme: boolean;
 }
@@ -17,4 +19,5 @@ export const themeSlice = createSlice({
 });
 
 export const { toggleTheme } = themeSlice.actions;
+export const selectTheme = (state: RootState) => state.theme.darkTheme;
 export default themeSlice.reducer;

--- a/src/redux/theme/themeSlice.ts
+++ b/src/redux/theme/themeSlice.ts
@@ -1,0 +1,20 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface ThemeState {
+  darkTheme: boolean;
+}
+
+const initialState = { darkTheme: false } as ThemeState;
+
+export const themeSlice = createSlice({
+  name: 'theme',
+  initialState,
+  reducers: {
+    toggleTheme: (state) => {
+      state.darkTheme = !state.darkTheme;
+    },
+  },
+});
+
+export const { toggleTheme } = themeSlice.actions;
+export default themeSlice.reducer;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,25 @@
+import { createTheme } from '@mui/material';
+
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    background: {
+      paper: '#f2f2f2',
+    },
+    text: {
+      primary: '#111111',
+    },
+  },
+});
+
+export const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    background: {
+      paper: '#222',
+    },
+    text: {
+      primary: '#fff',
+    },
+  },
+});


### PR DESCRIPTION
`state.theme` allows access to the 'darkTheme' property which is a boolean (true or false) to determine what theme the [ThemeProvider](https://mui.com/customization/theming/#themeprovider) should use. The palettes for these themes can be found within `src/styles/theme.ts` 